### PR TITLE
Fix bug: read properties of undefined

### DIFF
--- a/dmarc-reporter.js
+++ b/dmarc-reporter.js
@@ -49,7 +49,7 @@ const parseFile = async function (fileName) {
       setTextColor(r.row.policy_evaluated.dkim),
       Array.isArray(r.auth_results.dkim)
         ? r.auth_results.dkim.map((x) => x.selector || "").join(", ")
-        : r.auth_results.dkim.selector || "",
+        : r.auth_results.dkim?.selector || "",
       r.identifiers.header_from || "",
       r.identifiers.envelope_from || "",
       r.identifiers.envelope_to || "",


### PR DESCRIPTION
Adds null-aware behavior to fix crash if `dkim` object is undefined.

Expected behavior: creates the table.

Actual behavior: 

```shell
% node dmarc-reporter.js *.xml
~/source/dmarc-reporter/dmarc-reporter.js:52
        : r.auth_results.dkim.selector || "",
                              ^

TypeError: Cannot read properties of undefined (reading 'selector')
    at ~/source/dmarc-reporter/dmarc-reporter.js:52:31
    at Array.map (<anonymous>)
    at parseFile (~/source/dmarc-reporter/dmarc-reporter.js:43:30)
    at async parseFiles (~/source/dmarc-reporter/dmarc-reporter.js:67:18)

Node.js v22.0.0
```